### PR TITLE
Adds preliminary pathplanner example for vision

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,7 +137,7 @@ public class RobotContainer {
     Command driveSetpointGenKeyboard = drivebase.driveWithSetpointGeneratorFieldRelative(driveDirectAngleKeyboard);
 
     if (RobotBase.isSimulation()) {
-      drivebase.setDefaultCommand(driveFieldOrientedDirectAngleKeyboard);
+      drivebase.setDefaultCommand(driveFieldOrientedAngularVelocity);
     } else {
       drivebase.setDefaultCommand(driveFieldOrientedAngularVelocity);
     }
@@ -151,7 +151,7 @@ public class RobotContainer {
       drivebase.setDefaultCommand(driveFieldOrientedAngularVelocity); // Overrides drive command above!
 
       driverXbox.x().whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
-      driverXbox.y().whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
+      //driverXbox.y().whileTrue(drivebase.driveToDistanceCommand(1.0, 0.2));
       driverXbox.start().onTrue((Commands.runOnce(drivebase::zeroGyro)));
       driverXbox.back().whileTrue(drivebase.centerModulesCommand());
       driverXbox.leftBumper().onTrue(Commands.none());
@@ -175,7 +175,7 @@ public class RobotContainer {
       double robotXWidth = Constants.Vision.xWidth;
 
       driverXbox.b().whileTrue(
-        new SupplyAprilTagPose(vision, new Pose2d(), (pose) -> {
+        new SupplyAprilTagPose(vision, () -> drivebase.getPose(), (pose) -> {
                 Pose2d targetPose;
                 targetPose = new Pose2d(
                     pose.getTranslation().minus(

--- a/src/main/java/frc/robot/commands/vision/SupplyAprilTagPose.java
+++ b/src/main/java/frc/robot/commands/vision/SupplyAprilTagPose.java
@@ -25,11 +25,13 @@ public class SupplyAprilTagPose extends Command implements WithStatus {
     public static final int MAX_CYCLE_COUNT = 10;
 
     public final Supplier<List<Integer>> targetIds;
+    private Supplier<Pose2d> currentPose;
 
-    public SupplyAprilTagPose(VisionSubsystem s_Vision, Pose2d currentPose, Consumer<Pose2d> setTargetPose, Supplier<List<Integer>> targetIds) {
+    public SupplyAprilTagPose(VisionSubsystem s_Vision, Supplier<Pose2d> currentRobotPose, Consumer<Pose2d> setTargetPose, Supplier<List<Integer>> targetIds) {
         this.s_Vision = s_Vision;
         this.setTargetPose = setTargetPose;
         this.targetIds = targetIds;
+        this.currentPose = currentRobotPose;
 
         System.out.println(targetIds);
 
@@ -56,7 +58,7 @@ public class SupplyAprilTagPose extends Command implements WithStatus {
         
         if (result.isEmpty()) {
             counter += 1;
-            System.out.println("Cycle: " + counter);
+            //System.out.println("Cycle: " + counter);
             return;
         }
 
@@ -71,6 +73,7 @@ public class SupplyAprilTagPose extends Command implements WithStatus {
 
         Pose2d poseToAprilTag = s_Vision.getPoseTo(target);
         System.out.println("> April Tag: " + poseToAprilTag);
+        System.out.println("> currentPose: " + currentPose.get());
 
         setTargetPose.accept(poseToAprilTag);
         targetPoseSet = true;

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -262,6 +262,9 @@ public class SwerveSubsystem extends SubsystemBase {
    * @return PathFinding command
    */
   public Command driveToPose(Pose2d pose) {
+
+    System.out.println("> targetPose for path planner: " + pose);
+
     // Create the constraints to use while pathfinding
     PathConstraints constraints = new PathConstraints(
         swerveDrive.getMaximumChassisVelocity(), 4.0,


### PR DESCRIPTION
This pull request is a (somewhat) working example of using the pathplanner "driveToPose" function from the YAGSL.  Since the command that it returns relies on the targetPose being set in SupplyAprilTagPose, we must use a "DeferredCommand".  If we don't, the targetPose is set in the pathplanner command before it is set by the callback in SupplyAprilTagPose.  The rotation does appear to work with driveToPose - but we should probably test how close it can be to the target pose translation before it prevents rotation.  Hopefully it's close enough that we could just skip the drive and just execute a Spin command.

Notes: 

- Most of the interesting changes are in the DriveToReef command.
- I also modified the driving strategy in the RobotContainer so that I could rotate the robot with the joystick

**This pull request is informational only, I am not planning to merge it**